### PR TITLE
Start managing dependencies with a glide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ _testmain.go
 node_modules/
 test_results/
 .vscode/
+
+# ignore glide dependencies
+vendor

--- a/dbMongo/db_mongo.go
+++ b/dbMongo/db_mongo.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 
 	"github.com/ElectricCookie/go-waechter"
-	mgo "gopkg.in/mgo.v2"
-	"gopkg.in/mgo.v2/bson"
+	mgo "github.com/go-mgo/mgo"
+	"github.com/go-mgo/mgo/bson"
 )
 
 //MongoAdapter is a ready adapter to connect go-waechter to mongodb

--- a/emailSmtp/email_smtp.go
+++ b/emailSmtp/email_smtp.go
@@ -2,7 +2,7 @@ package emailSmtp
 
 import (
 	waechter "github.com/ElectricCookie/go-waechter"
-	gomail "gopkg.in/gomail.v2"
+	gomail "github.com/go-gomail/gomail"
 )
 
 //New creates a new SMTP adapter

--- a/glide.lock
+++ b/glide.lock
@@ -1,0 +1,111 @@
+hash: d39856edb2307370a67aa2fae0c896edada1bd4ee7bf9c78e40132bfb39b7d87
+updated: 2017-08-07T22:14:08.6403102+02:00
+imports:
+- name: github.com/dgrijalva/jwt-go
+  version: d2709f9f1f31ebcda9651b03077758c1f3a0018c
+- name: github.com/gin-contrib/sse
+  version: 22d885f9ecc78bf4ee5d72b937e4bbcdc58e8cae
+- name: github.com/gin-gonic/gin
+  version: d459835d2b077e44f7c9b453505ee29881d5d12d
+  subpackages:
+  - binding
+  - render
+- name: github.com/golang/protobuf
+  version: 748d386b5c1ea99658fd69fe9f03991ce86a90c1
+  subpackages:
+  - proto
+- name: github.com/mattn/go-isatty
+  version: fc9e8d8ef48496124e79ae0df75490096eccf6fe
+- name: github.com/ugorji/go
+  version: 5efa3251c7f7d05e5d9704a69a984ec9f1386a40
+  subpackages:
+  - codec
+- name: golang.org/x/crypto
+  version: 76c7c60c071b310d16774257b879b9d476db77f3
+  subpackages:
+  - pbkdf2
+  - scrypt
+- name: golang.org/x/sys
+  version: d8f5ea21b9295e315e612b4bcf4bedea93454d4d
+  subpackages:
+  - unix
+- name: gopkg.in/alexcesaro/quotedprintable.v3
+  version: 2caba252f4dc53eaf6b553000885530023f54623
+- name: gopkg.in/asaskevich/govalidator.v4
+  version: 4918b99a7cb949bb295f3c7bbaf24b577d806e35
+- name: gopkg.in/go-playground/validator.v8
+  version: 5f1438d3fca68893a817e4a66806cea46a9e4ebf
+- name: gopkg.in/gomail.v2
+  version: 81ebce5c23dfd25c6c67194b37d3dd3f338c98b1
+- name: gopkg.in/mgo.v2
+  version: 3f83fa5005286a7fe593b055f0d7771a7dce4655
+  subpackages:
+  - bson
+  - internal/json
+  - internal/sasl
+  - internal/scram
+- name: gopkg.in/yaml.v2
+  version: 25c4ec802a7d637f88d584ab26798e94ad14c13b
+testImports:
+- name: github.com/braintree/manners
+  version: 0b5e6b2c2843f4c83c2a40f96980b09cf4af733c
+- name: github.com/franela/goreq
+  version: b5b0f5eb2d16f20345cce0a544a75163579c0b00
+- name: github.com/onsi/ginkgo
+  version: 9eda700730cba42af70d53180f9dcce9266bc2bc
+  subpackages:
+  - config
+  - internal/codelocation
+  - internal/containernode
+  - internal/failer
+  - internal/leafnodes
+  - internal/remote
+  - internal/spec
+  - internal/spec_iterator
+  - internal/specrunner
+  - internal/suite
+  - internal/testingtproxy
+  - internal/writer
+  - reporters
+  - reporters/stenographer
+  - reporters/stenographer/support/go-colorable
+  - reporters/stenographer/support/go-isatty
+  - types
+- name: github.com/onsi/gomega
+  version: c893efa28eb45626cdaa76c9f653b62488858837
+  subpackages:
+  - format
+  - internal/assertion
+  - internal/asyncassertion
+  - internal/oraclematcher
+  - internal/testingtsupport
+  - matchers
+  - matchers/support/goraph/bipartitegraph
+  - matchers/support/goraph/edge
+  - matchers/support/goraph/node
+  - matchers/support/goraph/util
+  - types
+- name: golang.org/x/net
+  version: f5079bd7f6f74e23c4d65efa0f4ce14cbd6a3c0f
+  subpackages:
+  - html
+  - html/atom
+  - html/charset
+- name: golang.org/x/text
+  version: 3bd178b88a8180be2df394a1fbb81313916f0e7b
+  subpackages:
+  - encoding
+  - encoding/charmap
+  - encoding/htmlindex
+  - encoding/internal
+  - encoding/internal/identifier
+  - encoding/japanese
+  - encoding/korean
+  - encoding/simplifiedchinese
+  - encoding/traditionalchinese
+  - encoding/unicode
+  - internal/tag
+  - internal/utf8internal
+  - language
+  - runes
+  - transform

--- a/glide.lock
+++ b/glide.lock
@@ -1,6 +1,8 @@
-hash: d39856edb2307370a67aa2fae0c896edada1bd4ee7bf9c78e40132bfb39b7d87
-updated: 2017-08-07T22:14:08.6403102+02:00
+hash: 25b167f40a2f90699e787e8b9d4ff768377f4301840120e443fe05a2b51d263f
+updated: 2017-08-07T23:12:34.6081251+02:00
 imports:
+- name: github.com/asaskevich/govalidator
+  version: 4918b99a7cb949bb295f3c7bbaf24b577d806e35
 - name: github.com/dgrijalva/jwt-go
   version: d2709f9f1f31ebcda9651b03077758c1f3a0018c
 - name: github.com/gin-contrib/sse
@@ -10,6 +12,12 @@ imports:
   subpackages:
   - binding
   - render
+- name: github.com/go-gomail/gomail
+  version: 81ebce5c23dfd25c6c67194b37d3dd3f338c98b1
+- name: github.com/go-mgo/mgo
+  version: 3f83fa5005286a7fe593b055f0d7771a7dce4655
+  subpackages:
+  - bson
 - name: github.com/golang/protobuf
   version: 748d386b5c1ea99658fd69fe9f03991ce86a90c1
   subpackages:
@@ -31,12 +39,8 @@ imports:
   - unix
 - name: gopkg.in/alexcesaro/quotedprintable.v3
   version: 2caba252f4dc53eaf6b553000885530023f54623
-- name: gopkg.in/asaskevich/govalidator.v4
-  version: 4918b99a7cb949bb295f3c7bbaf24b577d806e35
 - name: gopkg.in/go-playground/validator.v8
   version: 5f1438d3fca68893a817e4a66806cea46a9e4ebf
-- name: gopkg.in/gomail.v2
-  version: 81ebce5c23dfd25c6c67194b37d3dd3f338c98b1
 - name: gopkg.in/mgo.v2
   version: 3f83fa5005286a7fe593b055f0d7771a7dce4655
   subpackages:
@@ -47,10 +51,6 @@ imports:
 - name: gopkg.in/yaml.v2
   version: 25c4ec802a7d637f88d584ab26798e94ad14c13b
 testImports:
-- name: github.com/braintree/manners
-  version: 0b5e6b2c2843f4c83c2a40f96980b09cf4af733c
-- name: github.com/franela/goreq
-  version: b5b0f5eb2d16f20345cce0a544a75163579c0b00
 - name: github.com/onsi/ginkgo
   version: 9eda700730cba42af70d53180f9dcce9266bc2bc
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,0 +1,24 @@
+package: github.com/ElectricCookie/go-waechter
+import:
+- package: github.com/dgrijalva/jwt-go
+  version: ^3.0.0
+- package: github.com/gin-gonic/gin
+  version: ^1.2.0
+- package: golang.org/x/crypto
+  subpackages:
+  - scrypt
+- package: gopkg.in/asaskevich/govalidator.v4
+  version: ^6.0.0
+- package: gopkg.in/gomail.v2
+  version: ^2.0.0
+- package: gopkg.in/mgo.v2
+  subpackages:
+  - bson
+testImport:
+- package: github.com/braintree/manners
+  version: ^0.4.0
+- package: github.com/franela/goreq
+- package: github.com/onsi/ginkgo
+  version: ^1.4.0
+- package: github.com/onsi/gomega
+  version: ^1.2.0

--- a/glide.yaml
+++ b/glide.yaml
@@ -7,17 +7,16 @@ import:
 - package: golang.org/x/crypto
   subpackages:
   - scrypt
-- package: gopkg.in/asaskevich/govalidator.v4
+- package: github.com/asaskevich/govalidator
   version: ^6.0.0
-- package: gopkg.in/gomail.v2
+- package: github.com/go-gomail/gomail
   version: ^2.0.0
-- package: gopkg.in/mgo.v2
+- package: github.com/go-mgo/mgo
+  version: ^2.0.0
   subpackages:
   - bson
+- package: github.com/gin-contrib/sse
 testImport:
-- package: github.com/braintree/manners
-  version: ^0.4.0
-- package: github.com/franela/goreq
 - package: github.com/onsi/ginkgo
   version: ^1.4.0
 - package: github.com/onsi/gomega

--- a/transportGin/transporter_gin_test.go
+++ b/transportGin/transporter_gin_test.go
@@ -2,7 +2,9 @@ package transportGin_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	waechter "github.com/ElectricCookie/go-waechter"
@@ -10,8 +12,6 @@ import (
 	"github.com/ElectricCookie/go-waechter/localeDefault"
 	"github.com/ElectricCookie/go-waechter/testEmail"
 	"github.com/ElectricCookie/go-waechter/transportGin"
-	"github.com/braintree/manners"
-	"github.com/franela/goreq"
 	"github.com/gin-gonic/gin"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -19,10 +19,9 @@ import (
 
 func makeRequest(method string, endpoint string, parameters interface{}, result interface{}, cookies *http.Cookie) *waechter.AuthError {
 
-	req := goreq.Request{
-		Uri:    "http://127.0.0.1:3333" + endpoint,
-		Method: method,
-		Body:   parameters,
+	req, err := http.NewRequest(method, endpoint, parameters)
+	if err != nil {
+		panic(err)
 	}
 
 	if cookies != nil {
@@ -89,9 +88,7 @@ var _ = Describe("User:Register", func() {
 
 	ginC.DefaultRoutes(r)
 
-	go func() {
-		manners.ListenAndServe("127.0.0.1:3333", r)
-	}()
+	s := httptest.NewServer(r)
 
 	Describe("Register", func() {
 
@@ -99,7 +96,7 @@ var _ = Describe("User:Register", func() {
 			res := struct {
 				Token string `json:"token"`
 			}{}
-			authErr := makeRequest("POST", "/auth/register", waechter.UserRegisterParams{
+			authErr := makeRequest("POST", fmt.Sprint(s.URL, "/auth/register"), waechter.UserRegisterParams{
 				Username:  "ElectricCookie",
 				Password:  "Password123",
 				Email:     "test-email@foo.com",
@@ -234,7 +231,7 @@ var _ = Describe("User:Register", func() {
 
 	AfterSuite(func() {
 		// Close the server to allow the program to shut down properly.
-		manners.Close()
+		s.Close()
 
 	})
 

--- a/user_forgot-password.go
+++ b/user_forgot-password.go
@@ -1,7 +1,7 @@
 package waechter
 
 import (
-	validator "gopkg.in/asaskevich/govalidator.v4"
+	validator "github.com/asaskevich/govalidator"
 )
 
 //ForgotPasswordParams describes parameters passed to ForgotPassword

--- a/user_register.go
+++ b/user_register.go
@@ -3,7 +3,7 @@ package waechter
 import (
 	"time"
 
-	validator "gopkg.in/asaskevich/govalidator.v4"
+	validator "github.com/asaskevich/govalidator"
 )
 
 //UserRegisterParams are the parameters used to register a new user.

--- a/user_send_verification.go
+++ b/user_send_verification.go
@@ -1,6 +1,6 @@
 package waechter
 
-import govalidator "gopkg.in/asaskevich/govalidator.v4"
+import govalidator "github.com/asaskevich/govalidator"
 
 //SendVerificationEmail sends an email to the user with a link to verify their email address
 func (waechter *Waechter) SendVerificationEmail(emailAddress string) (*string, *AuthError) {


### PR DESCRIPTION
- [x] Start using `glide`.
- [x] Drop `gopkg.io` deps. I think it does not make sense to use both `gopkg` and the glide, they do not work well together (especially in the `govalidator` dependency it will ignore tag from `gopkg.in`, and fetch the latest version by default), Also, it was documented in the [style guides](https://github.com/bahlo/go-styleguide).
- [x] Remove dependencies which can be easily replaced with std lib.
